### PR TITLE
feat: Make the SDK compatible with NodeJS 12

### DIFF
--- a/nodejs/bempaggo-kit-layers/tsconfig.json
+++ b/nodejs/bempaggo-kit-layers/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "moduleResolution": "node",
-        "target": "ES2020",
+        "target": "ES2019",
         "module": "CommonJS",
         "lib": [
-            "ES2020",
+            "ES2019",
             "DOM",
             "DOM.Iterable"
         ],

--- a/nodejs/bempaggo-kit-test/tsconfig.json
+++ b/nodejs/bempaggo-kit-test/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "moduleResolution": "node",
-        "target": "ES2020",
+        "target": "ES2019",
         "module": "CommonJS",
         "lib": [
-            "ES2020",
+            "ES2019",
             "DOM",
             "DOM.Iterable"
         ],

--- a/nodejs/bempaggo-kit/tsconfig.json
+++ b/nodejs/bempaggo-kit/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "moduleResolution": "node",
-        "target": "ES2020",
+        "target": "ES2019",
         "module": "CommonJS",
         "lib": [
-            "ES2020",
+            "ES2019",
             "DOM",
             "DOM.Iterable"
         ],


### PR DESCRIPTION
Na Layers Education precisamos que o SDK funcione com o NodeJS 12. O target do SDK usado no `tsconfig.json` estava como ECMA2020, essa versão é compatível apenas a partir do NodeJS 14. Mudando pra ECMA2019 funciona no NodeJS 12 também.